### PR TITLE
feat: add minimal airdrop tracker website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-Backend BookShelf-API
+# Backend BookShelf-API
+
+This repository now includes a minimal website to track airdrop project progress.
+Open `public/index.html` in your browser to manage your airdrop list.
+
+Run the API server with:
+
+```
+npm start
+```

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,63 @@
+const form = document.getElementById('project-form');
+const list = document.getElementById('project-list');
+
+let projects = JSON.parse(localStorage.getItem('projects') || '[]');
+
+function save() {
+  localStorage.setItem('projects', JSON.stringify(projects));
+}
+
+function render() {
+  list.innerHTML = '';
+  projects.forEach((p, idx) => {
+    const li = document.createElement('li');
+
+    const header = document.createElement('div');
+    header.className = 'project-header';
+
+    const title = document.createElement('div');
+    title.textContent = p.name;
+
+    const remove = document.createElement('button');
+    remove.textContent = '✕';
+    remove.className = 'remove-btn';
+    remove.addEventListener('click', () => {
+      projects.splice(idx, 1);
+      save();
+      render();
+    });
+
+    header.appendChild(title);
+    header.appendChild(remove);
+    li.appendChild(header);
+
+    if (p.description) {
+      const desc = document.createElement('div');
+      desc.textContent = p.description;
+      li.appendChild(desc);
+    }
+
+    const bar = document.createElement('div');
+    bar.className = 'progress-bar';
+    const fill = document.createElement('div');
+    fill.style.width = `${p.progress}%`;
+    bar.appendChild(fill);
+    li.appendChild(bar);
+
+    list.appendChild(li);
+  });
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const name = document.getElementById('name').value.trim();
+  const description = document.getElementById('description').value.trim();
+  const progress = parseInt(document.getElementById('progress').value, 10) || 0;
+
+  projects.push({ name, description, progress });
+  save();
+  render();
+  form.reset();
+});
+
+render();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Airdrop Tracker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>Airdrop Tracker</h1>
+    <form id="project-form">
+      <input type="text" id="name" placeholder="Project name" required />
+      <input type="text" id="description" placeholder="Description" />
+      <input type="number" id="progress" placeholder="Progress (%)" min="0" max="100" value="0" />
+      <button type="submit">Add</button>
+    </form>
+    <ul id="project-list"></ul>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,84 @@
+:root {
+  --primary: #6200ee;
+  --background: #f5f5f5;
+  --text: #333;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--background);
+  color: var(--text);
+  display: flex;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.container {
+  width: 100%;
+  max-width: 600px;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+
+form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+form input {
+  flex: 1 1 45%;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+form button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+.project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+
+.progress-bar {
+  height: 6px;
+  background: #ddd;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.progress-bar div {
+  height: 100%;
+  background: var(--primary);
+}
+
+.remove-btn {
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add static airdrop tracker page with modern minimal layout
- store project progress in browser local storage
- ignore node_modules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2c437bae4832fa6b3111fa1d68ae9